### PR TITLE
Patch sandbox update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /venv/
 .env
 .coverage
-#return NOWPayments("005D77S-WM24Z3A-Q0RQHM9-1FS3HH5")

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The api call descriptions are from the official documentation.
 ## Getting Started
 Before using the NOWPayments API, sign up for a [API key here](https://nowpayments.io/).
 
-If you want to use the Sandbox, request your [API key here](https://account.sandbox.nowpayments.io/).
+If you want to use the Sandbox, request your [API key here](https://account-sandbox.nowpayments.io/).
 
 
 To install the wrapper, enter the following into the terminal.
@@ -38,6 +38,3 @@ payment = NOWPaymentsSandbox("SANDBOX_API_KEY")
 
 status = payment.get_api_status()
 ```
-
-
-

--- a/src/nowpayments/sandbox.py
+++ b/src/nowpayments/sandbox.py
@@ -10,7 +10,7 @@ class NOWPaymentsSandbox(NOWPayments):
     """
 
     ### This has recently been changed from https://api.sandbox.nowpayments.io/v1/ to this.
-    API_URL = "https://api-sandbox.nowpayments.io/v1/"
+    API_URL = "https://api-sandbox.nowpayments.io/v1/{}"
 
     def create_payment(
         self,

--- a/src/nowpayments/sandbox.py
+++ b/src/nowpayments/sandbox.py
@@ -9,4 +9,72 @@ class NOWPaymentsSandbox(NOWPayments):
     Class to used for the NOWPayments API Sandbox.
     """
 
-    API_URL = "https://api.sandbox.nowpayments.io/v1/{}"
+    ### This has recently been changed from https://api.sandbox.nowpayments.io/v1/ to this.
+    API_URL = "https://api-sandbox.nowpayments.io/v1/"
+
+    def create_payment(
+        self,
+        price_amount: float,
+        price_currency: str,
+        pay_currency: str,
+        **kwargs: Union[str, float, bool, int],
+    ) -> Dict:
+        """
+        With this method, your customer will be able to complete the payment without leaving
+        your website.
+
+        :param float price_amount: The fiat equivalent of the price to be paid in crypto.
+
+        :param str price_currency: The fiat currency in which the price_amount is specified.
+
+        :param str pay_currency: The crypto currency in which the pay_amount is specified.
+
+        :param float pay_amount: The amount that users have to pay for the order stated in crypto.
+
+        :param str ipn_callback_url: Url to receive callbacks, should contain "http" or "https".
+
+        :param str order_id: Inner store order ID.
+
+        :param str order_description: Inner store order description.
+
+        :param int purchase_id: Id of purchase for which you want to create a other payment.
+
+        :param str payout_address: Receive funds on another address.
+
+        :param str payout_currency: Currency of your external payout_address.
+
+        :param int payout_extra_id: Extra id or memo or tag for external payout_address.
+
+        :param bool fixed_rate: Required for fixed-rate exchanges.
+
+        :param str case: Used to change the outcome of the payment, defaults to "success" other options are "fail" and "partially_paid"
+
+        refer to https://documenter.getpostman.com/view/7907941/T1LSCRHC
+        """
+        endpoint = "payment"
+        data = {
+            "price_amount": price_amount,
+            "price_currency": price_currency,
+            "pay_amount": None,
+            "pay_currency": pay_currency,
+            "ipn_callback_url": None,
+            "order_id": None,
+            "order_description": None,
+            "buy_id": None,
+            "payout_address": None,
+            "payout_currency": None,
+            "payout_extra_id": None,
+            "fixed_rate": None,
+            "case": "success"
+        }
+        data.update(**kwargs)
+        if len(data) != 13:
+            raise TypeError("create_payment() got an unexpected keyword argument")
+
+        url = self.get_url(endpoint)
+        resp = self.post_requests(url, data=data)
+        if resp.status_code == 201:
+            return resp.json()
+        raise HTTPError(
+            f'Error {resp.status_code}: {resp.json().get("message", "Not descriptions")}'
+        )


### PR DESCRIPTION
# Reasons
- Before the sandbox api url was outdated location at <https://api.sandbox.nowpayments.io/v1/>, where the correct current location is <https://api-sandbox.nowpayments.io/v1/>
- Also before we couldn't change the case of the transaction in the NOWpayments api, which was a useful feature
- Leak of api key in the .gitignore file
- Fixed in ReadME where the URL to create an account is

## Actions
- Changed the api_url to [current one](https://api-sandbox.nowpayments.io/v1/)
- Deleted the api key in the .gitignore file ```#return NOWPayments("XXXXXXX-XXXXXXX-XXXXXXX-XXXXX")```
  - Recommend deleting this api key and creating a new one
- Created an override method in the sandbox class with 1 more parameter (case) where it can be success, fail, or "partially_paid"